### PR TITLE
fix: Get the postal code optional

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -19,7 +19,8 @@
       "type": "password"
     },
     "zipcode": {
-      "type": "text"
+      "type": "text",
+      "isRequired": "false"
     }
   },
   "folders": [


### PR DESCRIPTION
A quick to get the optional postal code really option in harvest.