### PR TITLE
fix: Add employment_center_certificate to manifest

### DIFF
--- a/manifest.konnector
+++ b/manifest.konnector
@@ -108,7 +108,8 @@
   },
   "banksTransactionRegExp": "\\bpole emploi\\b",
   "qualification_labels": [
-    "unemployment_benefit"
+    "unemployment_benefit",
+    "employment_center_certificate"
   ],
   "features": [
     "VENDOR_REF",


### PR DESCRIPTION
In order to show the HarvestBanner whithin the MesPapiers app. Should also fix the blank page on MesPapiers to suggest the installation of this konnector