### PR TITLE
fix: Add another awaited element to check login

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -146,7 +146,7 @@ class PoleemploiContentScript extends ContentScript {
       isOlderVersion = oldVersion
     }
     await this.waitForElementInWorker(
-      'button[data-target="#PopinDeconnexion"], pe-header[isLogged="true"]'
+      'button[data-target="#PopinDeconnexion"], pe-header[isLogged="true"], .btn-account-connected'
     )
     await this.ensureLogout(isOlderVersion)
     await this.navigateToLoginForm()


### PR DESCRIPTION
With the available accounts, they change the login detection selectors. As we know the website got many different version depending on the user, I thought it was better to keep the others just to fit all possibilities.