### PR TITLE
Fix/wait for messages

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,9 @@ const log = Minilog('ContentScript')
 Minilog.enable('poleemploiCCC')
 
 // Necessary here because they are using these functions and they are not supported by the webview
-console.group = function () {}
-console.groupCollapsed = function () {}
-console.groupEnd = function () {}
+console.group = function () { }
+console.groupCollapsed = function () { }
+console.groupEnd = function () { }
 
 const requestInterceptor = new RequestInterceptor([
   {
@@ -294,17 +294,7 @@ class PoleemploiContentScript extends ContentScript {
   async fetchMessages() {
     this.log('info', '📍️ fetchMessages starts')
     await this.goto(courriersPageUrl)
-    // await this.waitForElementInWorker('.courriers, .subtitle')
-    await Promise.race([
-      this.waitForElementInWorker('.courriers'),
-      this.waitForElementInWorker('.subtitle', {
-        includesText: 'aucun courrier'
-      })
-    ])
-    if (!(await this.isElementInWorker('.courriers'))) {
-      this.log('warn', 'No courriers found at all')
-      return []
-    }
+    await this.waitForRequestInterception('userMessages')
     const interceptedMessages = this.store.userMessages.payload.response
     const computedMessages = await this.computeMessages(
       interceptedMessages.ressources

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,9 @@ const log = Minilog('ContentScript')
 Minilog.enable('poleemploiCCC')
 
 // Necessary here because they are using these functions and they are not supported by the webview
-console.group = function () { }
-console.groupCollapsed = function () { }
-console.groupEnd = function () { }
+console.group = function () {}
+console.groupCollapsed = function () {}
+console.groupEnd = function () {}
 
 const requestInterceptor = new RequestInterceptor([
   {
@@ -31,7 +31,8 @@ requestInterceptor.init()
 
 const PDF_HEADERS = {
   Accept: 'application/json, text/plain, */*',
-  'Content-Type': 'application/pdf'
+  'Content-Type': 'application/pdf',
+  typeAuth: '/individu'
 }
 
 // const baseUrl = 'https://www.francetravail.fr/accueil/'
@@ -313,7 +314,6 @@ class PoleemploiContentScript extends ContentScript {
         'https://api.pole-emploi.fr/documents-usager/v2/courriers/'
       const vendorRef = message.idDn
       const fileurl = `${courriersUrl}${vendorRef}`
-
       const computedMessage = {
         date,
         type,


### PR DESCRIPTION
Awaited element for "no messages" is appearing briefly during the page loading. This was causing the konnector to find it everytime, leading it to think no messages were found on the user profile. Now we're juste exepcting the request to show up, as the konnector is design to handle both situation. 
They also add a new header in the download requests that were missing in the konnector.